### PR TITLE
Generate APP_KEY before config:cache in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN docker-php-ext-configure opcache --enable-opcache && \
 
 COPY --from=build /app /var/www/html
 
-RUN php artisan config:cache && \
+RUN cp /var/www/html/.env.example /var/www/html/.env && \
+    php artisan key:generate --force && \
+    php artisan config:cache && \
     php artisan route:cache && \
     chmod 777 -R /var/www/html/storage/ && \
     chown -R www-data:www-data /var/www/


### PR DESCRIPTION
Copy .env.example and generate APP_KEY before running config:cache, otherwise an empty key gets baked into the cached config and all requests return 500.